### PR TITLE
Fix for issue #4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(name='YourAppName',
       author='Your Name',
       author_email='example@example.com',
       url='http://www.python.org/sigs/distutils-sig/',
-      install_requires=['Flask=0.7.2', 'MarkupSafe' , 'Flask-SQLAlchemy=0.16'],
+      install_requires=['Flask==0.7.2', 'MarkupSafe' , 'Flask-SQLAlchemy==0.16'],
      )


### PR DESCRIPTION
`install_requires` line in `setup.py` used incorrect single-equals to
specify component versions. This change updates the file with
double-equals to fix the issue.